### PR TITLE
feat: Implement configuration overlay system

### DIFF
--- a/.github/workflows/rust-clippy.yml
+++ b/.github/workflows/rust-clippy.yml
@@ -1,0 +1,56 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# rust-clippy is a tool that runs a bunch of lints to catch common
+# mistakes in your Rust code and help improve your Rust code.
+# More details at https://github.com/rust-lang/rust-clippy
+# and https://rust-lang.github.io/rust-clippy/
+
+name: rust-clippy analyze
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "main" ]
+  schedule:
+    - cron: '29 17 * * 5'
+
+jobs:
+  rust-clippy-analyze:
+    name: Run rust-clippy analyzing
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read # only required for a private repository by github/codeql-action/upload-sarif to get the Action run status
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af #@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
+
+      - name: Install required cargo
+        run: cargo install clippy-sarif sarif-fmt
+
+      - name: Run rust-clippy
+        run:
+          cargo clippy
+          --all-features
+          --message-format=json | clippy-sarif | tee rust-clippy-results.sarif | sarif-fmt
+        continue-on-error: true
+
+      - name: Upload analysis results to GitHub
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: rust-clippy-results.sarif
+          wait-for-processing: true
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,10 @@ async fn run() -> AppResult<()> {
         fs::create_dir_all(&data_dir)?;
         tracing::trace!(path = %data_dir.display(), "Created data directory");
 
+        // --- Create the configuration overlay ---
+        config::symlink_unmanaged_configs(&env_dir)?;
+        tracing::info!("Created symlink overlay for unmanaged configurations");
+
         // --- Overall Progress Bar ---
         let tools_to_provision = ["fish", "starship", "zoxide", "atuin", "ripgrep", "helix"];
         let total_steps = (tools_to_provision.len() + 1) as u64; // Tools + config step


### PR DESCRIPTION
This change introduces a configuration overlay system that allows the isolated environment to inherit user-wide configurations for unmanaged tools.

The system works by symlinking all files and directories from the user's global `~/.config` directory into the environment's `config` directory, unless they are explicitly managed by isoterm (e.g., fish, starship).

This allows tools like `gh` or `gcloud` to use their existing authentication tokens and configurations from within the isolated environment without requiring manual setup.